### PR TITLE
Difference between back-up and master branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
 YFLAGS = -d
+OBJS = \
+	argv.o \
+	exec.o \
+	lexer.o \
+	misc.o \
+	open.o \
+	parser.o \
+	var.o
 
 all: sh
 
@@ -7,9 +15,11 @@ check: sh test
 		'./test hello <input.txt world' | ./sh
 	cmp output.txt expect.txt
 
-sh: parser.o lexer.o
+sh: $(OBJS)
 
 lexer.o: parser.o
+
+$(OBJS): command.h
 
 clean:
 	-rm -f y.* *.o sh test output.txt

--- a/argv.c
+++ b/argv.c
@@ -1,0 +1,31 @@
+#include "command.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+char **newargv(void)
+{
+	char **argv = (char **)calloc(sizeof *argv, 2);
+	
+	oomtest(argv, "calloc");
+	argv[0] = "";
+
+	return argv;
+}
+
+char **addarg(char **argv, char *arg)
+{
+	int argc;
+
+	if (!argv)
+		argv = newargv();
+
+	argc = veclen(argv) + 1;
+	argv = (char **)realloc(argv, (argc + 1) * sizeof arg);
+	argv[argc - 1] = arg;
+	argv[argc] = NULL;
+
+	return argv;
+}

--- a/command.h
+++ b/command.h
@@ -1,0 +1,24 @@
+#ifndef _COMMAND_H
+#define _COMMAND_H
+
+enum {
+	INPUT, OUTPUT, APPEND, FORCEOUT, INOUTPUT,
+	HEREDOC, HEREIND, DUPIN, DUPOUT
+};
+
+extern int fdin, fdout;
+
+int veclen(char **vec);
+void oomtest(const void *ptr, const char *str);
+char *copyword(const char *word);
+
+char **newargv(void);
+char **addarg(char **argv, char *arg);
+char **newenvp(void);
+char **addvar(char **envp, char *var);
+
+void openio(int num, int redir, char *file);
+
+void issuecmd(char *name, char **argv, char **envp);
+
+#endif

--- a/exec.c
+++ b/exec.c
@@ -1,0 +1,31 @@
+#include "command.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void issuecmd(char *name, char **argv, char **envp)
+{
+	if (!envp)
+		envp = newenvp();
+	if (!argv)
+		argv = newargv();
+
+	assert(envp);
+	assert(argv);
+	assert(name);
+	argv[0] = name;
+
+	if (-1 != fdin) {
+		dup2(fdin, 0);
+		close(fdin);
+	}
+	if (-1 != fdout) {
+		dup2(fdout, 1);
+		close(fdout);
+	}
+
+	execve(name, argv, envp);
+	perror("execve");
+	exit(EXIT_FAILURE);
+}

--- a/lexer.l
+++ b/lexer.l
@@ -1,47 +1,45 @@
 %{
 #include "y.tab.h"
+
+#include "command.h"
+
+#include <stdlib.h>
 %}
 
-WORD [[:alpha:]][[:alnum:]]*
+ASSIGN [_a-zA-Z][0-9_a-zA-Z]*=[^# \t\n<>&]*
+UNSPEC [^# \t\n=<>&]*=[^# \t\n<>&]*
+WORD [^# \t\n<>&][^# \t\n=<>&]*
 
 %%
 
-#.*|[ \t\n]+ /* Ignore comments and spaces */
+#.*|[ \t]+
+
+[0-9]+/[<>] {
+	yylval.num = atoi(yytext);
+	return IONUM;
+}
+
+"<<" return LELE;
+">>" return GRGR;
+"<&" return LEAND;
+">&" return GRAND;
+"<>" return LEGR;
+"<<-" return LELEDASH;
+">|" return CLOBBER;
+
+{ASSIGN} {
+	yylval.word = copyword(yytext);
+	return ASSIGN;
+}
+
+{UNSPEC} {
+	yylval.word = copyword(yytext);
+	return UNSPEC;
+}
 
 {WORD} {
-	/*
-	 * The yylval variable represents the token value.
-	 * This variable is external variable for the lexer
-	 * and is defined by the parser.
-	 * Technically this variable has the union type.
-	 * That union's fields are defined by the %union { ... }
-	 * statement in the parser.
-	 *
-	 * The lexer recognizes strings matching the regular
-	 * expressions defined in the second section, that is
-	 * one starting from the first line %% in the lexer.
-	 * Each statement of this section is a rule of the form
-	 * `REGEXP actions;', where REGEXP is either a regular
-	 * expression or `{NAME}' (the regular expression
-	 * defined in the first section of the lexer), while
-	 * actions are basically written in the C language with
-	 * some additional variables and macros available.
-	 *
-	 * In this particular case, the union has a field `str'
-	 * of type (char *), and we assign the string matching
-	 * the regular expression named WORD as the token value.
-	 */
-	yylval.str = yytext;
-
+	yylval.word = copyword(yytext);
 	return WORD;
 }
 
-\<\< return DLESS;
-\>\> return DGREAT;
-\<& return LESSAND;
-\>& return GREATAND;
-\<\> return LESSGREAT;
-\<\<- return DLESSDASH;
-\>\| return CLOBBER;
-
-. return yytext[0];
+\n|. return yytext[0];

--- a/misc.c
+++ b/misc.c
@@ -1,0 +1,42 @@
+#include "command.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+void unspec(const char *ref)
+{
+	assert(ref);
+	fprintf(stderr, "Unspecified: %s\n", ref);
+	exit(EXIT_FAILURE);
+}
+
+int veclen(char **vec)
+{
+	int len = 0;
+
+	assert(vec);
+	while (vec[len])
+		++len;
+
+	return len;
+}
+
+void oomtest(const void *ptr, const char *str)
+{
+	if (!ptr) {
+		assert(str);
+		perror(str);
+		exit(EXIT_FAILURE);
+	}
+}
+
+char *copyword(const char *word)
+{
+	char *copy = strdup(word);
+
+	oomtest(copy, "strdup");
+	
+	return copy;
+}

--- a/open.c
+++ b/open.c
@@ -1,0 +1,58 @@
+#include "command.h"
+
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+
+int fdin = -1;
+int fdout = -1;
+
+static void openin(char *file)
+{
+	if (-1 != fdin) {
+		if (close(fdin)) {
+			perror("close");
+			exit(EXIT_FAILURE);
+		}
+		fdin = -1;
+	}
+
+	assert(file);
+	fdin = open(file, O_RDONLY);
+	if (-1 == fdin) {
+		perror(file);
+		exit(EXIT_FAILURE);
+	}
+	free(file);
+}
+
+static void openout(char *file)
+{
+	mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+
+	if (-1 != fdout) {
+		if (close(fdout)) {
+			perror("close");
+			exit(EXIT_FAILURE);
+		}
+		fdout = -1;
+	}
+
+	assert(file);
+	fdout = creat(file, mode);
+	if (-1 == fdout) {
+		perror(file);
+		exit(EXIT_FAILURE);
+	}
+	free(file);
+}
+
+void openio(int num, int redir, char *file)
+{
+	if (OUTPUT == redir)
+		openout(file);
+	else if (INPUT == redir)
+		openin(file);
+}

--- a/sh.c
+++ b/sh.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 
 int main(int argc, char *argv[])
 {

--- a/var.c
+++ b/var.c
@@ -1,0 +1,30 @@
+#include "command.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+char **newenvp(void)
+{
+	char **envp = (char **)calloc(sizeof *envp, 1);
+	
+	oomtest(envp, "calloc");
+
+	return envp;
+}
+
+char **addvar(char **envp, char *var)
+{
+	int len;
+
+	if (!envp)
+		envp = newenvp();
+
+	len = veclen(envp) + 1;
+	envp = (char **)realloc(envp, (len + 1) * sizeof var);
+	envp[len - 1] = var;
+	envp[len] = NULL;
+
+	return envp;
+}


### PR DESCRIPTION
This pull request is meant for discussing the difference between the original master branch saved as `backup` and the current one, namely `master`. It has a single commit representing the difference due to failed attempt to distinguish any milestones in the original history. It is however possible to identify the following points by looking at the resulting patch.
1. Draft routines to handle unspecified behavior, which should be covered while working on issue #3.
2. A more accurate regular expression for WORD tokens.
3. Regular expressions for assignments.
4. Corrected regular expression for comments and spaces to ignore.
5. Regular expression to distinguish numbered I/O redirection symbols.
6. Simpler regular expressions for I/O redirection tokens, without escaping characters.
7. Simplified grammar rules, deviating from the original POSIX node names.
8. Introducing `cmd` structure into the parser to handle collecting of `argv[]` values.
9. Basic implementation of `exec*(2)`ution with sane redirection of file descriptors.
