### PR TITLE
Module for unspecified behavior routine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ YFLAGS = -d
 OBJS = \
 	lexer.o \
 	parser.o \
-	sh.o
+	sh.o \
+	unspec.o
 
 all: sh
 
@@ -14,6 +15,8 @@ check: sh test
 
 sh: $(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $(OBJS) -ly -ll
+
+$(OBJS): command.h
 
 lexer.o: y.tab.h
 

--- a/command.h
+++ b/command.h
@@ -1,0 +1,7 @@
+#ifndef _COMMAND_H
+#define _COMMAND_H
+
+void unspec(const char *ref);
+void *chkptr(void *ptr, const char *cause);
+
+#endif

--- a/unspec.c
+++ b/unspec.c
@@ -1,0 +1,22 @@
+#include "command.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+void unspec(const char *ref)
+{
+	assert(ref);
+	fprintf(stderr, "Unspecified: %s\n", ref);
+	exit(EXIT_FAILURE);
+}
+
+void *chkptr(void *ptr, const char *cause)
+{
+	if (!ptr) {
+		perror(cause);
+		exit(EXIT_FAILURE);
+	}
+
+	return ptr;
+}


### PR DESCRIPTION
Introduces a new module unspec.c with two helper routines called unspec() and chkptr() as well as a new header command.h that provides the interface for those two helpers. The unspec() routine is the unspecified behavior routine mentioned in the issue #3. The chkptr() routine is similar to unspec(), but is meant to handle out-of-memory situation when indicated by *alloc() and strdup() system interfaces.
