### PR TITLE
Allow line-joining in IO_NUMBER token

### DIFF
--- a/lexer.l
+++ b/lexer.l
@@ -72,7 +72,7 @@ WORD ({LITER}({LJ}{LITER})*)
 <MAIN>{EMPTY}+ ;
 <MAIN>\n return NEWLINE;
 
-<MAIN>[0-9]+/[<>] {
+<MAIN>([0-9]{LJ})+/[<>] {
 	yylval.str = chkptr(strdup(yytext), "strdup");
 	fprintf(stderr, "IO_NUMBER '%s'\n", yylval.str);
 	return IO_NUMBER;


### PR DESCRIPTION
Partially covers #17. Allows escaped newline characters to appear in IO_NUMBER tokens. Fixes the order of substitute definitions. Replaces the negative [^\n] regular expression across the lexer.l source with shorter equivalent positive dot (.) expression.
