### PR TITLE
Lexer table sizes reduction

### DIFF
--- a/lexer.l
+++ b/lexer.l
@@ -22,14 +22,8 @@ QUOTE ('[^']*')
 CMDQUOTE (`([^`\\]|{LJ}|{ESC})*`)
 DQUOTE (\"([^"\\$]|{LJ}|{ESC}|{CMDQUOTE}|{PAREXP})*\")
 LITER ({CHAR}|{ESC}|{QUOTE}|{DQUOTE}|{CMDQUOTE}|{PAREXP})
-WORD ({LITER}({LJ}{LITER})*)
 
-%a 20000
-%n 2000
-%o 30000
-%p 30000
-
-%x MAIN
+%X MAIN TOKEN
 
 %%
 
@@ -94,12 +88,19 @@ WORD ({LITER}({LJ}{LITER})*)
 <MAIN>[(<&|;>)] return yytext[0];
 
 <MAIN>([0-9]{LJ})+/[<>] {
+	/* XCU 2.10.1, item #3. */
 	yylval.str = chkptr(strdup(yytext), "strdup");
 	fprintf(stderr, "IO_NUMBER '%s'\n", yylval.str);
 	return IO_NUMBER;
 }
 
-<MAIN>{WORD} {
+<MAIN>. {
+	/* XCU 2.3, item #11. */
+	BEGIN TOKEN;
+	yyless(0);
+}
+
+<TOKEN>{LJ}{LITER}/[(<&|;>) \t\n] {
 	/*
 	 * The yylval variable represents the token value.
 	 * This variable is external variable for the lexer
@@ -109,14 +110,37 @@ WORD ({LITER}({LJ}{LITER})*)
 	 * statement in the parser.
 	 *
 	 * In this particular case, the union has a field `str'
-	 * of type (char *), and we assign the string matching
-	 * the regular expression named WORD as the token value.
+	 * of type (char *), and we assign the string accumulated
+	 * in the yytext buffer as the token value; see also
+	 * the comment on the yymore() routine call below.
 	 * The string duplication is necessary due to yytext
 	 * possibly modified before the token reaches the parser.
 	 */
+	BEGIN MAIN;
 	yylval.str = chkptr(strdup(yytext), "strdup");
 	fprintf(stderr, "WORD '%s'\n", yylval.str);
 	return WORD;
 }
 
-<MAIN>. unspec("XCU 2");
+<TOKEN>{LJ}{LITER}/. {
+	/*
+	 * The current token is not to be delimited just yet.
+	 * A yymore() call makes the next token to be appended to
+	 * yytext variable rather than replacing its value.
+	 */
+	yymore();
+}
+
+<TOKEN>{LJ}{LITER} {
+	/*
+	 * The end-of-file is a valid token delimiter;
+	 * see XCU 2.3 Token Recognition, item #1.
+	 * This action is assumed to be taken at the end
+	 * of input because niether of the previous regular
+	 * expressions matched the current input.
+	 */
+	BEGIN MAIN;
+	yylval.str = chkptr(strdup(yytext), "strdup");
+	fprintf(stderr, "WORD '%s'\n", yylval.str);
+	return WORD;
+}


### PR DESCRIPTION
Completely covers issue #24 and partially covers issue #17. The solid regular expression named WORD is replaced with several lexer rules under a new exclusive state TOKEN. The latter significantly decreases the required lexer table sizes so that they can fit into minimal limits mandatory for conforming implementation of the lex(1) utility.
