### PR TITLE
Grammatically accept an arbitrary Shell script

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -47,6 +47,9 @@
    The Grammar
    ------------------------------------------------------- */
 
+script           : linebreak
+                 | compound_list
+                 ;
 compound_list    : linebreak term
                  | linebreak term separator
                  ;


### PR DESCRIPTION
This pull request introduces a conflicts-free version of complete Shell program grammar instead of that reverted by pull request #30. The new main `script` grammar rule accepts zero or more commands, unlike the originally main `complete_command` grammar rule that accepts exactly one command. This change is necessary to proceed with the issue #17 regarding implementation of token recognition.
