### PR TITLE
Align to IEEE 1003.1-2013 + TC2

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -17,7 +17,8 @@
 %token  IO_NUMBER
 
 
-/* The following are the operators mentioned above. */
+/* The following are the operators (see XBD Section 3.260)
+   containing more than one character. */
 
 
 %token  AND_IF    OR_IF    DSEMI
@@ -103,7 +104,8 @@ compound_list    : linebreak term
 term             : term separator and_or
                  |                and_or
                  ;
-for_clause       : For name linebreak                            do_group
+for_clause       : For name                                      do_group
+                 | For name                       sequential_sep do_group
                  | For name linebreak in          sequential_sep do_group
                  | For name linebreak in wordlist sequential_sep do_group
                  ;


### PR DESCRIPTION
Regarding issue #17, concludes aligning to IEEE 1003.1-2013 original standard Shell Grammar Rules with TC2 applied, merging final accepted solutions for issues 581 and 648 in the Austin Group Defect Tracker. Indeed, final accepted solutions for issues 735, 736, and 737 have already been applied during previous pull requests #30, #31, #32, #33, and #35, and TC2 contains no more changes against Shell Grammar Rules. Applying solutions for issues 581 and 648 results in no shift/reduce conflicts in the grammar when processed by `yacc(1)`.