### PR TITLE
Align to IEEE 1003.1-2016

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -17,8 +17,9 @@
 %token  IO_NUMBER
 
 
-/* The following are the operators (see XBD Section 3.260)
+/* The following are the operators (see XBD Operator)
    containing more than one character. */
+
 
 
 %token  AND_IF    OR_IF    DSEMI


### PR DESCRIPTION
Regarding issue #17, aligns to IEEE 1003.1-2016 final version of Shell Grammar Rules.
